### PR TITLE
changed path of cover image to be consistent

### DIFF
--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -3,7 +3,7 @@
     {{ $cover := . }}
     <div id="cover" style="background-image:url('{{ $cover | absURL }}');"></div>
   {{ else }}
-    {{ $cover := (printf "images/%s" .) }}
+    {{ $cover := (printf "%s" .) }}
     <div id="cover" style="background-image:url('{{ $cover | absURL }}');"></div>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Previously the path for cover image and other images were inconsistent. This resulted in a problem where the cover image wasn't showing for me. This is a proposed fix for the problem